### PR TITLE
Passes along the output of cache hit to the outputs of the composite action

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -23,6 +23,9 @@ outputs:
   cache-key:
     description: Cache key holding Golang build and module cache paths.
     value: ${{ steps.golang-env.outputs.cache-key }}
+  cache-hit:
+    description: Cache hit result
+    value: ${{ steps.set-cache-hit.outputs.cache-hit }}
 
 runs:
   using: composite
@@ -43,6 +46,7 @@ runs:
         echo "cache-key=${cacheKeyRoot}${{ hashFiles('**/go.sum') }}" >>"$GITHUB_OUTPUT"
       shell: bash
     - name: Setup Golang cache
+      id: cache
       uses: actions/cache@v3
       with:
         path: |
@@ -51,3 +55,8 @@ runs:
         key: ${{ steps.golang-env.outputs.cache-key }}
         restore-keys: |
           ${{ steps.golang-env.outputs.cache-key-restore }}
+    - name: Set cache-hit output
+      id: set-cache-hit
+      run: echo "cache-hit=${{ steps.cache.outputs.cache-hit }}" >>"$GITHUB_OUTPUT"
+      shell: bash
+  


### PR DESCRIPTION
For issue https://github.com/magnetikonline/action-golang-cache/issues/3

Tested this using:

```
- name: Debug
  run: echo "${{ steps.setup-go.outputs.cache-hit }}"
```

```
2023-07-21T21:27:04.4474613Z [command]/usr/bin/tar -xf /home/runner/work/_temp/687ce039-194e-4e4a-ab55-4a04f8c9fd58/cache.tzst -P -C /home/runner/work/ark/ark --use-compress-program unzstd
2023-07-21T21:27:04.4591910Z Cache restored successfully
2023-07-21T21:27:04.4883501Z Cache restored from key: Linux-golang-c61d69d173a3ee00c37bb90b92c1cbb4c51afca3d8f744d713cd987506696aef
2023-07-21T21:27:04.5006495Z ##[group]Run echo "cache-hit=true" >>"$GITHUB_OUTPUT"
2023-07-21T21:27:04.5006877Z [36;1mecho "cache-hit=true" >>"$GITHUB_OUTPUT"[0m
2023-07-21T21:27:04.5057857Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
2023-07-21T21:27:04.5058179Z ##[endgroup]
2023-07-21T21:27:04.5213605Z ##[group]Run echo "true"
2023-07-21T21:27:04.5213918Z [36;1mecho "true"[0m
2023-07-21T21:27:04.5260801Z shell: /usr/bin/bash -e {0}
```